### PR TITLE
Fix Lap recording when going from one session to the next.

### DIFF
--- a/src/processv2csvimpl.cpp
+++ b/src/processv2csvimpl.cpp
@@ -199,7 +199,9 @@ namespace pcars
         currenttime_.time = -1;
         currenttime_.tick = 0;
         currenttime_.distance = 0;
-        state_ = 0;      
+        state_ = 0;
+        nextlap_ = 0;
+        currentlap_ = 0; 
     }
 
 } // namespace pcars


### PR DESCRIPTION
This fixes recording of laps when you go from one session to another, if you finish practise and  then go straight to qualy or race the laps did not start recording until you passed the amount of laps you did in practise.  example if I did 2 laps in practise and then went to race the lap recording would not start until lap 3. Hopefully this fixes that issue.