### PR TITLE
Add lap time to output message

### DIFF
--- a/inc/processv2csvmsgimpl.h
+++ b/inc/processv2csvmsgimpl.h
@@ -13,9 +13,14 @@ namespace pcars
 
         void updateTelemetry(Packet::Ptr &) override;
         void writeCapturedTelemetryToCSV() override;
-    
+        void updateCurrentLap() override;
+        void reset() override;
+        void clearTelemetry() override;
+
     private:
         float lastlaptime_;
+        bool neednextpackets_;
+        bool needlastlaptime_;
     };
 
 } // namespace pcars

--- a/inc/processv2csvmsgimpl.h
+++ b/inc/processv2csvmsgimpl.h
@@ -13,6 +13,9 @@ namespace pcars
 
         void updateTelemetry(Packet::Ptr &) override;
         void writeCapturedTelemetryToCSV() override;
+    
+    private:
+        float lastlaptime_;
     };
 
 } // namespace pcars

--- a/src/processv2csvmsgimpl.cpp
+++ b/src/processv2csvmsgimpl.cpp
@@ -40,6 +40,7 @@ namespace pcars
                 lastlaptime_ = p->stats().at(0).last_lap_time();
                 cout << "   Time: " << timestamp(lastlaptime_) << endl;
                 needlastlaptime_ = false;
+                cout.flush();
             }
         }
     }
@@ -59,6 +60,7 @@ namespace pcars
             cout << "Record lap: " << currentlap_;
             neednextpackets_ = false;
             needlastlaptime_ = true;
+            cout.flush();
         }
         else
         {

--- a/src/processv2csvmsgimpl.cpp
+++ b/src/processv2csvmsgimpl.cpp
@@ -2,6 +2,7 @@
 #include "../inc/packettimestatsdata.h"
 
 #include <iostream>
+#include <sstream>
 
 using namespace std;
 
@@ -9,22 +10,71 @@ namespace pcars
 {
     ProcessV2CSVImpl::Names messages;
 
+    string timestamp(float time)
+    {
+        stringstream ss;
+        ss << static_cast<unsigned int>(time / 60); // mins
+        ss << ':';
+        if (static_cast<unsigned int>(time) % 60 < 10)
+        {
+            ss << '0';
+        }
+        ss << static_cast<unsigned int>(time) % 60 + (time - (static_cast<unsigned int>(time)));
+        return ss.str();
+    }
+
     ProcessV2CSVMSGImpl::ProcessV2CSVMSGImpl()
         : ProcessV2CSVImpl("inputs", messages),
-          lastlaptime_{0} {}
+          lastlaptime_{0},
+          neednextpackets_{false},
+          needlastlaptime_{false} {}
 
     void ProcessV2CSVMSGImpl::updateTelemetry(Packet::Ptr &packet)
     {
-        if (packet->type() == PACKETTYPE::PACKETTIMESTATSDATA)
+        if (needlastlaptime_)
         {
-            PacketTimeStatsData *p = dynamic_cast<PacketTimeStatsData *>(packet.get());
+            if (packet->type() == PACKETTYPE::PACKETTIMESTATSDATA)
+            {
+                PacketTimeStatsData *p = dynamic_cast<PacketTimeStatsData *>(packet.get());
 
-            lastlaptime_ = p->stats().at(0).last_lap_time();
+                lastlaptime_ = p->stats().at(0).last_lap_time();
+                cout << "   Time: " << timestamp(lastlaptime_) << endl;
+                needlastlaptime_ = false;
+            }
+        }
+    }
+
+    void ProcessV2CSVMSGImpl::updateCurrentLap()
+    {
+        if (!neednextpackets_)
+        {
+            currentlap_ = nextlap_;
         }
     }
 
     void ProcessV2CSVMSGImpl::writeCapturedTelemetryToCSV()
     {
-        cout << "Record lap: " << currentlap_ << " Time: " << lastlaptime_ << endl;
+        if (neednextpackets_)
+        {
+            cout << "Record lap: " << currentlap_;
+            neednextpackets_ = false;
+            needlastlaptime_ = true;
+        }
+        else
+        {
+            neednextpackets_ = true;
+        }
+    }
+
+    void ProcessV2CSVMSGImpl::reset()
+    {
+        ProcessV2CSVImpl::reset();
+        neednextpackets_ = false;
+        needlastlaptime_ = false;
+    }
+
+    void ProcessV2CSVMSGImpl::clearTelemetry()
+    {
+        ProcessV2CSVImpl::clearTelemetry();
     }
 }

--- a/src/processv2csvmsgimpl.cpp
+++ b/src/processv2csvmsgimpl.cpp
@@ -1,4 +1,5 @@
 #include "../inc/processv2csvmsgimpl.h"
+#include "../inc/packettimestatsdata.h"
 
 #include <iostream>
 
@@ -9,15 +10,21 @@ namespace pcars
     ProcessV2CSVImpl::Names messages;
 
     ProcessV2CSVMSGImpl::ProcessV2CSVMSGImpl()
-        : ProcessV2CSVImpl("inputs", messages) {}
+        : ProcessV2CSVImpl("inputs", messages),
+          lastlaptime_{0} {}
 
     void ProcessV2CSVMSGImpl::updateTelemetry(Packet::Ptr &packet)
     {
-        // do nothing
+        if (packet->type() == PACKETTYPE::PACKETTIMESTATSDATA)
+        {
+            PacketTimeStatsData *p = dynamic_cast<PacketTimeStatsData *>(packet.get());
+
+            lastlaptime_ = p->stats().at(0).last_lap_time();
+        }
     }
 
     void ProcessV2CSVMSGImpl::writeCapturedTelemetryToCSV()
     {
-        cout << "Write lap " << currentlap_ << " telemetry to CSV file." << endl;
+        cout << "Record lap: " << currentlap_ << " Time: " << lastlaptime_ << endl;
     }
 }

--- a/src/telemetrymsg.cpp
+++ b/src/telemetrymsg.cpp
@@ -39,23 +39,9 @@ namespace pcars
             Position pos = 0;
             packetBase.decode(data, pos);
 
-            if (packetBase.packet_type() == 0 && data.size() == 559)
-            {
-                shared_ptr<Packet> packet = make_shared<PacketTelemetryData>();
-                pos = 0;
-                packet->decode(data, pos);
-                capture.capturePacket(packet);
-            }
-            else if (packetBase.packet_type() == 1 && data.size() == 308)
+            if (packetBase.packet_type() == 1 && data.size() == 308)
             {
                 shared_ptr<Packet> packet = make_shared<PacketRaceData>();
-                pos = 0;
-                packet->decode(data, pos);
-                capture.capturePacket(packet);
-            }
-            else if (packetBase.packet_type() == 2 && data.size() == 1136)
-            {
-                shared_ptr<Packet> packet = make_shared<PacketParticipantsData>();
                 pos = 0;
                 packet->decode(data, pos);
                 capture.capturePacket(packet);
@@ -77,20 +63,6 @@ namespace pcars
             else if (packetBase.packet_type() == 7 && data.size() == 1040)
             {
                 shared_ptr<Packet> packet = make_shared<PacketTimeStatsData>();
-                pos = 0;
-                packet->decode(data, pos);
-                capture.capturePacket(packet);
-            }
-            else if (packetBase.packet_type() == 8 && data.size() == 1164)
-            {
-                shared_ptr<Packet> packet = make_shared<PacketParticipantsVehicleNamesData>();
-                pos = 0;
-                packet->decode(data, pos);
-                capture.capturePacket(packet);
-            }
-            else if (packetBase.packet_type() == 8 && data.size() == 1452)
-            {
-                shared_ptr<Packet> packet = make_shared<PacketVehicleClassNamesData>();
                 pos = 0;
                 packet->decode(data, pos);
                 capture.capturePacket(packet);


### PR DESCRIPTION
Output looks like this now when you finish a lap

```
Press 'q' then 'Enter' to QUIT.
Listening on port 5606
Record lap: 1   Time: 0:58.5371
Record lap: 2   Time: 0:57.1758
Record lap: 3   Time: 1:9.22437
Record lap: 1   Time: 1:6.50879
Record lap: 2   Time: 1:6.50854
```

There is an issue if you come to the last lap it will record the lap but MAY not display the lap time, this is because the last lap time is after the lap has finished and may not capture it before going to the menu screen.